### PR TITLE
Include theme in your template

### DIFF
--- a/src/stubs/app.scss
+++ b/src/stubs/app.scss
@@ -16,8 +16,9 @@ $xlarge-min: 1220px;
 // UIkit 3
 
 // Base
-@import 'node_modules/uikit/src/scss/variables.scss';
-@import 'node_modules/uikit/src/scss/mixins.scss';
+@import 'node_modules/uikit/src/scss/variables-theme.scss';
+@import 'node_modules/uikit/src/scss/mixins-theme.scss';
+@import "node_modules/uikit/src/scss/theme/_import.scss";
 @import 'node_modules/uikit/src/scss/components/base.scss';
 @import 'node_modules/uikit/src/scss/components/inverse.scss';
 


### PR DESCRIPTION
Much easier start I guess and the suggested way from the [docs](https://getuikit.com/docs/sass#how-to-build).

Without themes, styling is different from what a new user might expect as they browse the official documentation. Form input for example has no border ... the difference was confusing to me at first.
 
Maybe we can suggest including original files and comment it out? Or just reverse it and comment out the themed files?

I agree on including each component separately as it is much easier to remove the non-used before going to production. Consider abstracting it in a separate file. Importing that from app.scss would clean it up a bit and make a safer environment while editing the variables.