### PR TITLE
Update UIKit3Preset.php

### DIFF
--- a/src/UIKit3Preset.php
+++ b/src/UIKit3Preset.php
@@ -67,7 +67,7 @@ class UIKit3Preset extends Preset
      */
     protected static function updateBootstrapping()
     {
-        copy(__DIR__.'/stubs/app.scss', resource_path('assets/sass/app.scss'));
+        copy(__DIR__.'/stubs/app.scss', resource_path('sass/app.scss'));
 
         tap(new Filesystem, function ($filesystem) {
             $filesystem->delete(resource_path('assets/sass/_variables.scss'));
@@ -75,12 +75,12 @@ class UIKit3Preset extends Preset
             $bootstrapJs = str_replace(
                 "require('bootstrap');",
                 "window.UIkit = require('uikit');",
-                $filesystem->get(resource_path('assets/js/bootstrap.js'))
+                $filesystem->get(resource_path('js/bootstrap.js'))
             );
 
             $bootstrapJs = str_replace("window.Popper = require('popper.js').default;", '', $bootstrapJs);
 
-            $filesystem->put(resource_path('assets/js/bootstrap.js'), $bootstrapJs);
+            $filesystem->put(resource_path('js/bootstrap.js'), $bootstrapJs);
         });
     }
 


### PR DESCRIPTION
assets folder not present anymore in new Laravel installation.
I got the same issue #16 removing the assets folder from the path and run again artisan preset solved my problem. 